### PR TITLE
GLOCINT-2441: Searching didn't work correctly when SearchParameter us…

### DIFF
--- a/src/fhir/meta_index.coffee
+++ b/src/fhir/meta_index.coffee
@@ -117,9 +117,9 @@ module.exports.parameter = (idx, path)->
     throw new Error("MetaIndex: Path not expandable #{path.join('-')}")
 
   epathes.map (epath)->
-    epath = epath.map((x)-> if lang.isArray(x) then x[0] else x)
-    el = element(idx, epath)
-    throw new Error("MetaIndex: Element [#{JSON.stringify(path)}] -> #{epath.join('.')} not found") unless el
+    epathFirstDimensionOnly = epath.map((x)-> if lang.isArray(x) then x[0] else x)
+    el = element(idx, epathFirstDimensionOnly)
+    throw new Error("MetaIndex: Element [#{JSON.stringify(path)}] -> #{epathFirstDimensionOnly.join('.')} not found") unless el
 
     name: name
     path: epath


### PR DESCRIPTION
Searching didn't work correctly when SearchParameter used attribute search syntax in the XPath definition, e.g.

`f:Practitioner/f:extension[@url='http://hl7.org/fhir/StructureDefinition/Practitioner-contact-display']/f:valueString`

In this case a FHIR query:

`SELECT fhir_search(cast('{"resourceType": "Practitioner", "queryString": "Practitioner-contact-display:contains=abcd"}' as json));`

was resolved to a plain SQL query without taking into account the `@url` selector:

```
SELECT tbl1.*
FROM "practitioner" tbl1
WHERE
    fhir_extract_as_string(
        ("tbl1"."resource")::json,
        ('[{"path":["Practitioner","extension","valueString"],"elementType":"string"}]')::json
    ) ilike '%abcd%';
```

In the place where the fix is applied we could see that even if `epath` before mapping was:

`["Practitioner",["extension",["url","http://hl7.org/fhir/StructureDefinition/Practitioner-contact-display"]],"valueString"]`

then after mapping it was stripped only to the first dimension:

`["Practitioner","extension","valueString"]`

After applying a fix a stripped epath is passed to the `element` function, but original `epath` with all selectors is returned by the `parameter` function.

As a result a resolved plain SQL query has a multidimensional path parameter that contains selector for `url` attribute:

```
SELECT tbl1.*
FROM "practitioner" tbl1
WHERE
    fhir_extract_as_string(
        ("tbl1"."resource")::json,
        ('[{"path":["Practitioner",["extension",["url","http://hl7.org/fhir/StructureDefinition/Practitioner-contact-display"]],"valueString"],"elementType":"string"}]')::json
    ) ilike '%abcd%';
```

and returns correct resources, limited only to those that have searched value in the specific, required extension (defined by URL), instead of resources that have searched value in any extension.

**Not known or barely known technologies touched for these three lines change:** 
- [x] Coffee Script
- [x] Functional programming
- [x] Lisp
- [x] Honey SQL
- [x] TypeScript
- [x] plv8
- [x] and 39 browser tabs opened